### PR TITLE
セッションの消去機能

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,16 @@
+name: test
+on: [push]
+jobs:
+  exec-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: start container
+        working-directory: .devcontainer
+        run: docker-compose up -d
+      - name: setup test
+        working-directory: .devcontainer
+        run: docker-compose exec -T node bash -c "yarn && yarn proto"
+      - name: run test
+        working-directory: .devcontainer
+        run: docker-compose exec -T node bash -c "yarn test"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
         run: docker-compose up -d
       - name: setup test
         working-directory: .devcontainer
-        run: docker-compose exec -T node bash -c "yarn && yarn proto"
+        run: docker-compose exec -T node bash -c "apt-get update -y && apt-get install -y openssl && yarn && yarn proto"
       - name: run test
         working-directory: .devcontainer
-        run: docker-compose exec -T node bash -c "yarn migrate:prod &&yarn test"
+        run: docker-compose exec -T node bash -c "yarn migrate:prod && yarn test"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,4 +13,4 @@ jobs:
         run: docker-compose exec -T node bash -c "yarn && yarn proto"
       - name: run test
         working-directory: .devcontainer
-        run: docker-compose exec -T node bash -c "yarn test"
+        run: docker-compose exec -T node bash -c "yarn migrate:prod &&yarn test"

--- a/__tests__/grpc/Session.service.test.ts
+++ b/__tests__/grpc/Session.service.test.ts
@@ -1,0 +1,78 @@
+import { startGrpcServer, stopGrpcServer } from '../../src/grpc'
+import * as protoLoader from '@grpc/proto-loader'
+import path from 'path'
+import * as grpc from '@grpc/grpc-js'
+import { SessionService } from '../../generated'
+import { ServiceClientConstructor } from '@grpc/grpc-js/build/src/make-client'
+import { GrpcClient } from '../../src/grpc/type'
+import { v4 as uuid } from 'uuid'
+
+const def = protoLoader.loadSync(
+  path.resolve(__dirname, `../../protos/SessionService.proto`)
+)
+const pkg = grpc.loadPackageDefinition(def)
+const ClientConstructor = pkg.SessionService as ServiceClientConstructor
+let client: GrpcClient<SessionService>
+
+beforeAll(async () => {
+  await startGrpcServer()
+  client = (new ClientConstructor(
+    'localhost:50051',
+    grpc.ChannelCredentials.createInsecure()
+  ) as unknown) as GrpcClient<SessionService>
+})
+
+const userId = uuid()
+let sessionId = ''
+
+test('セッションを作成する', (done) => {
+  client.startSession({ userId }, (err, res) => {
+    expect(err).toBeNull()
+    expect(res?.session?.userId).toEqual(userId)
+    expect(res?.session?.sessionId).not.toBeNull()
+    sessionId = res?.session?.sessionId ?? ''
+    console.log(res)
+    done()
+  })
+})
+
+test('存在するセッションを返す', (done) => {
+  client.getSession({ sessionId }, (err, res) => {
+    console.log(err)
+    expect(err).toBeNull()
+    expect(res?.userId).toEqual(userId)
+    expect(res?.sessionId).toEqual(sessionId)
+    done()
+  })
+})
+
+test('存在しないセッションでエラーを返す', (done) => {
+  client.getSession({ sessionId: uuid() }, (err, res) => {
+    expect(err?.code).toBe(5)
+    done()
+  })
+})
+
+//未実装
+// test('セッションを消去する', (done) => {
+//   client.deleteSession({ sessionId }, (err, res) => {
+//     expect(err).toBeNull()
+//     done()
+//   })
+// })
+
+// test('存在しないセッションを消去するとエラーを返す', (done) => {
+//   client.deleteSession({ sessionId: uuid() }, (err, res) => {
+//     expect(err?.code).toBe(5)
+//     done()
+//   })
+// })
+
+// test('消去したセッションを得ようとしてもエラーを返す', (done) => {
+//   client.getSession({ sessionId }, (err, res) => {
+//     expect(err?.code).toBe(5)
+//     done()
+//   })
+// })
+
+afterAll(stopGrpcServer)

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -125,7 +125,7 @@ export default {
   // runner: "jest-runner",
 
   // The paths to modules that run some code to configure or set up the testing environment before each test
-  // setupFiles: [],
+  setupFiles: ['dotenv/config'],
 
   // A list of paths to modules that run some code to configure or set up the testing framework before each test
   // setupFilesAfterEnv: [],

--- a/protos/SessionService.proto
+++ b/protos/SessionService.proto
@@ -5,6 +5,7 @@ import "google/protobuf/timestamp.proto";
 service SessionService {
   rpc StartSession(StartSessionRequest) returns (StartSessionResponse);
   rpc GetSession(GetSessionRequest) returns (Session);
+  rpc DeleteSession(DeleteSessionRequest) returns (DeleteSessionResponse);
 }
 
 message StartSessionRequest { 
@@ -30,3 +31,9 @@ message Session {
   string user_id = 2;
   google.protobuf.Timestamp expired_at = 3;
 }
+
+message DeleteSessionRequest {
+  string session_id = 1;
+}
+
+message DeleteSessionResponse {}

--- a/src/database/prisma-client.ts
+++ b/src/database/prisma-client.ts
@@ -1,3 +1,3 @@
 import { PrismaClient } from '@prisma/client'
 
-export const prismaClient = new PrismaClient({ log: ['query'] })
+export const prismaClient = new PrismaClient({ log: ['error'] })

--- a/src/database/session.ts
+++ b/src/database/session.ts
@@ -29,3 +29,15 @@ export async function findActiveSessionById({
     },
   })
 }
+
+export async function deleteSessionById({
+  id,
+}: {
+  id: string
+}): Promise<{ id: string } | null> {
+  return await prismaClient.session.delete({
+    where: {
+      id,
+    },
+  })
+}


### PR DESCRIPTION
## 作成したもの
- テストがなかったので、新規実装・既存機能のテストを作成
- セッションの消去機能（DBから指定されたセッションIDのセッションをハードデリート）

## 共有知見
- openSSLの問題でprismaが正しく動かないため、最新のopenSSLを利用するためにnode18-slimのdockerimageを使おうとしたがnodeのバージョンを上げると`@grpc/grpc-js`がエラーを吐くため上げられない。
- 代わりにprismaをyarnでインストールする前に`apt-get install openssl` をすることで回避
- jestで環境変数が適用されない問題で躓いた。`jest.config.ts`で環境変数が適用されるように設定しましょう・・・。

## その他
ORMのバージョンを上げるとエラーログ等が親切になった感じがするので上げたかったけど怖かったので上げませんでした。