### PR TITLE
リリースActionの修正

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,11 +8,11 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           registry: ghcr.io
-          username: ${{ secrets.CR_USER }}
-          password: ${{ secrets.CR_PAT }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Set Tag Name
         run: echo "TAG_NAME=ghcr.io/twin-te/session-service:${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
       - name: Build


### PR DESCRIPTION
### 経緯
過去にsecretに設定したdocker login用のtokenの期限が切れてreleaseに失敗した

### 修正方法
release action内でdocker loginするために、今まではsecretに登録したtokenを使っていたが、GITHUB_TOKENが自動で付与されるようになったので、切り替える。